### PR TITLE
 シーンを切り替える際に相互参照になってしまうバグの修正

### DIFF
--- a/Summoners-Aster/SceneSwitcher/SceneEventPostOffice.cpp
+++ b/Summoners-Aster/SceneSwitcher/SceneEventPostOffice.cpp
@@ -1,0 +1,46 @@
+﻿#include "SceneEventPostOffice.h"
+
+namespace summonersaster
+{
+	std::vector<SceneSwitchEvent*> SceneEventPostOffice::m_pSceneSwitchEventPosts;
+
+	void SceneEventPostOffice::RegisterReceiver(SceneSwitchEvent* pSceneSwitchEventPost)
+	{
+		m_pSceneSwitchEventPosts.push_back(pSceneSwitchEventPost);
+	}
+
+	void SceneEventPostOffice::UnRegisterReceiver(SceneSwitchEvent* pSceneSwitchEventPost)
+	{
+		for (auto pPost : m_pSceneSwitchEventPosts)
+		{
+			int index = static_cast<int>(&pPost - &m_pSceneSwitchEventPosts[0]);
+
+			//ポインタが同じじゃなかったら
+			if (pPost != pSceneSwitchEventPost) continue;
+
+			//要素を削除する
+			m_pSceneSwitchEventPosts.erase(m_pSceneSwitchEventPosts.begin() + index);
+
+			return;
+		}
+	}
+
+	void SceneEventPostOffice::SendSceneSwitchEvent(Scene::KIND nextScene)
+	{
+		for (auto pPost : m_pSceneSwitchEventPosts)
+		{
+			pPost->m_nextScene = nextScene;
+			pPost->m_shouldSwitch = true;
+		}
+	}
+
+	SceneEventPostOffice::SceneEventPostOffice()
+	{
+
+	}
+
+	SceneEventPostOffice::~SceneEventPostOffice()
+	{
+
+	}
+} // namespace summonersaster

--- a/Summoners-Aster/SceneSwitcher/SceneEventPostOffice.h
+++ b/Summoners-Aster/SceneSwitcher/SceneEventPostOffice.h
@@ -1,0 +1,60 @@
+﻿#ifndef SCENE_EVENT_POST_OFFICE_H
+#define SCENE_EVENT_POST_OFFICE_H
+
+#include <vector>
+
+#include <GameFramework.h>
+
+#include "Scene/Scene.h"
+
+namespace summonersaster
+{
+	/// <summary>
+	/// シーン切り替え情報
+	/// </summary>
+	struct SceneSwitchEvent
+	{
+		Scene::KIND m_nextScene;
+
+		/// <summary>
+		/// シーンの初期化を行うべきかを判断する
+		/// </summary>
+		/// <remarks>
+		/// 現在のシーンを初期化する必要が出てきた時に対応するため
+		/// </remarks>
+		bool m_shouldSwitch = false;
+	};
+
+	/// <summary>
+	/// シーンに関するイベント伝達の仲介クラス
+	/// </summary>
+	class SceneEventPostOffice
+	{
+	public:
+		/// <summary>
+		/// イベントの受取先の登録
+		/// </summary>
+		/// <param name="pSceneSwitchEventPost">イベントを受け取るポインタ</param>
+		static void RegisterReceiver(SceneSwitchEvent* pSceneSwitchEventPost);
+
+		/// <summary>
+		/// イベント受け取りの解除
+		/// </summary>
+		/// <param name="pSceneSwitchEventPost">イベントを受け取っているポインタ</param>
+		static void UnRegisterReceiver(SceneSwitchEvent* pSceneSwitchEventPost);
+
+		/// <summary>
+		/// 登録されている受取先全てにシーン切り替えイベントを送る
+		/// </summary>
+		/// <param name="nextScene">次からのシーン</param>
+		static void SendSceneSwitchEvent(Scene::KIND nextScene);
+
+	private:
+		SceneEventPostOffice();
+		~SceneEventPostOffice();
+
+		static std::vector<SceneSwitchEvent*> m_pSceneSwitchEventPosts;
+	};
+} // namespace summonersaster
+
+#endif //!SCENE_EVENT_POST_OFFICE_H

--- a/Summoners-Aster/SceneSwitcher/SceneSwitcher.cpp
+++ b/Summoners-Aster/SceneSwitcher/SceneSwitcher.cpp
@@ -9,7 +9,7 @@ namespace summonersaster
 
 	void SceneSwitcher::Update()
 	{
-		if (m_shouldInitialize)
+		if (m_sceneSwitchEventPost.m_shouldSwitch)
 		{
 			SwitchScene();
 		}
@@ -22,27 +22,21 @@ namespace summonersaster
 		m_pScenes[m_currentScene]->Render();
 	}
 
-	void SceneSwitcher::RegisterNextScene(Scene::KIND nextScene)
-	{
-		m_nextScene = nextScene;
-
-		m_shouldInitialize = true;
-	}
-
 	SceneSwitcher::SceneSwitcher()
 	{
 		CreateSceneInstances();
 		SwitchScene();
+		SceneEventPostOffice::RegisterReceiver(&m_sceneSwitchEventPost);
 	}
 
 	void SceneSwitcher::SwitchScene()
 	{
 		FinalizeCurrentScene();
 
-		m_currentScene = m_nextScene;
+		m_currentScene = m_sceneSwitchEventPost.m_nextScene;
 		InitializeCurrentScene();
 
-		m_shouldInitialize = false;
+		m_sceneSwitchEventPost.m_shouldSwitch = false;
 	}
 
 	void SceneSwitcher::InitializeCurrentScene()

--- a/Summoners-Aster/SceneSwitcher/SceneSwitcher.h
+++ b/Summoners-Aster/SceneSwitcher/SceneSwitcher.h
@@ -6,6 +6,7 @@
 #include <GameFramework.h>
 
 #include "Scene/Scene.h"
+#include "SceneEventPostOffice.h"
 
 using gameframework::Singleton;
 
@@ -33,12 +34,6 @@ namespace summonersaster
 		/// 現在のシーンの描画処理を行う
 		/// </summary>
 		void Render();
-
-		/// <summary>
-		/// 次のフレームから呼ばれるシーンを登録する
-		/// </summary>
-		/// <param name="nextScene">登録するシーン</param>
-		void RegisterNextScene(Scene::KIND nextScene);
 
 	private:
 		SceneSwitcher();
@@ -68,16 +63,8 @@ namespace summonersaster
 		/// </summary>
 		void ReleaseSceneInstances();
 
-		/// <summary>
-		/// シーンの初期化を行うべきかを判断する
-		/// </summary>
-		/// <remarks>
-		/// 現在のシーンを初期化する必要が出てきた時に対応するため
-		/// </remarks>
-		bool m_shouldInitialize = false;
-
 		Scene::KIND m_currentScene = Scene::KIND::TITLE;
-		Scene::KIND m_nextScene = Scene::KIND::TITLE;
+		SceneSwitchEvent m_sceneSwitchEventPost = { Scene::KIND::TITLE, false };
 
 		std::unordered_map<Scene::KIND, Scene*> m_pScenes;
 	};

--- a/Summoners-Aster/Summoners-Aster.vcxproj
+++ b/Summoners-Aster/Summoners-Aster.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="ObjectIntegrator\Object\Object.cpp" />
     <ClCompile Include="ObjectIntegrator\Object\Task.cpp" />
     <ClCompile Include="ObjectIntegrator\TaskScheduler.cpp" />
+    <ClCompile Include="SceneSwitcher\SceneEventPostOffice.cpp" />
     <ClCompile Include="SceneSwitcher\SceneSwitcher.cpp" />
     <ClCompile Include="SceneSwitcher\Scene\Scene.cpp" />
     <ClCompile Include="SceneSwitcher\Scene\TitleScene\GameTitle.cpp" />
@@ -38,6 +39,7 @@
     <ClInclude Include="ObjectIntegrator\Object\Object.h" />
     <ClInclude Include="ObjectIntegrator\Object\Task.h" />
     <ClInclude Include="ObjectIntegrator\TaskScheduler.h" />
+    <ClInclude Include="SceneSwitcher\SceneEventPostOffice.h" />
     <ClInclude Include="SceneSwitcher\SceneSwitcher.h" />
     <ClInclude Include="SceneSwitcher\Scene\Scene.h" />
     <ClInclude Include="SceneSwitcher\Scene\TitleScene\GameTitle.h" />

--- a/Summoners-Aster/Summoners-Aster.vcxproj.filters
+++ b/Summoners-Aster/Summoners-Aster.vcxproj.filters
@@ -61,6 +61,9 @@
     <ClInclude Include="SceneSwitcher\Scene\TitleScene\InputPrompt.h">
       <Filter>SceneSwitcher\Scene\TitleScene</Filter>
     </ClInclude>
+    <ClInclude Include="SceneSwitcher\SceneEventPostOffice.h">
+      <Filter>SceneSwitcher</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="SceneSwitcher\SceneSwitcher.cpp">
@@ -101,6 +104,9 @@
     </ClCompile>
     <ClCompile Include="SceneSwitcher\Scene\TitleScene\InputPrompt.cpp">
       <Filter>SceneSwitcher\Scene\TitleScene</Filter>
+    </ClCompile>
+    <ClCompile Include="SceneSwitcher\SceneEventPostOffice.cpp">
+      <Filter>SceneSwitcher</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## 元Issue
<!-- このPull Requestがマージされたときに閉じるIssue番号 -->
Closes #32

## 変更内容
<!-- このPull Requestでコードをどのように変更するか/変更したかを列挙する -->
- [x] イベント伝達クラスの作成
- [x] シーン切り替えクラスの修正

## 補足
イベント伝達クラスはイベント情報の書き替え伝達しか行わず
イベントハンドラは使用していません