### PR TITLE
✨プレイヤー関連クラスの作成

### DIFF
--- a/Summoners-Aster/SceneSwitcher/Scene/BattleScene/BattleObject.cpp
+++ b/Summoners-Aster/SceneSwitcher/Scene/BattleScene/BattleObject.cpp
@@ -1,0 +1,53 @@
+#include "BattleObject.h"
+
+using namespace gameframework;
+namespace summonersaster
+{
+
+BattleObject::BattleObject()
+{
+	GameFrameworkFactory::Create(&m_pRect);
+	GameFrameworkFactory::Create(&m_pStream);
+}
+
+BattleObject::~BattleObject()
+{
+	delete m_pRect;
+	delete m_pStream;
+}
+
+void BattleObject::SetVertex(const D3DXVECTOR3& center, const RectSize& size, const Color& color)
+{
+	m_pRect->SetCenterAndSizeAndColor(center, size, color);
+}
+
+void BattleObject::SetVertex(const D3DXVECTOR3& center, const RectSize& size, const Color& color, const TextureUVs& textureUVs)
+{
+	m_pRect->SetCenterAndSizeAndColorAndTextureUVs(center, size, color,textureUVs);
+}
+
+void BattleObject::DrowTexture(const TCHAR* pTextureKey)
+{
+	m_pRect->Render(m_rGameFramework.GetTexture(pTextureKey));
+}
+
+void BattleObject::WriteWords(D3DXVECTOR2 topLeft, const TCHAR* fontKey, int format)
+{
+	m_pStream->SetTopLeft(topLeft);
+	m_pStream->Render(m_rGameFramework.GetFont(fontKey), format);
+}
+
+void BattleObject::WriteWords(const D3DXVECTOR2 topLeft, const TCHAR* fontKey, int format, const gameframework::Color& color)
+{
+	m_pStream->SetTopLeft(topLeft);
+	m_pStream->SetColor(color);
+	m_pStream->Render(m_rGameFramework.GetFont(fontKey), format);
+}
+
+void BattleObject::SetString(const TCHAR* words)
+{
+	const tstring& str = words;
+	(*m_pStream) = str;
+
+}
+}

--- a/Summoners-Aster/SceneSwitcher/Scene/BattleScene/BattleObject.h
+++ b/Summoners-Aster/SceneSwitcher/Scene/BattleScene/BattleObject.h
@@ -1,0 +1,82 @@
+﻿#ifndef BATTLE_OBJECT_H
+#define BATTLE_OBJECT_H
+
+#include <GameFramework.h>
+namespace summonersaster
+{
+	class BattleObject
+{
+public:
+	BattleObject();
+	virtual ~BattleObject();
+
+	/// <summary>
+	/// 矩形情報の設定
+	/// </summary>
+	/// <param name="center">矩形の中心</param>
+	/// <param name="size">矩形の幅と高さ</param>
+	/// <param name="color">矩形の色</param>
+	void SetVertex(const D3DXVECTOR3& center, const gameframework::RectSize& size, const gameframework::Color& color);
+
+	/// <summary>
+	/// 矩形情報の設定
+	/// </summary>
+	/// <param name="center">矩形の中心</param>
+	/// <param name="size">矩形の幅と高さ</param>
+	/// <param name="color">矩形の色</param>
+	/// <param name="textureUVs">UV情報</param>
+	void SetVertex(const D3DXVECTOR3& center, const gameframework::RectSize& size, const gameframework::Color& color,const gameframework::TextureUVs& textureUVs);
+
+	/// <summary>
+	/// 画像の描画
+	/// </summary>
+	/// <param name="pTextureKey">テクスチャキー</param>
+	void DrowTexture(const TCHAR* pTextureKey);
+
+	/// <summary>
+	/// 文字列をフォントで描画
+	/// </summary>
+	/// <param name="topLeft">左上の位置</param>
+	/// <param name="fontKey">フォントキー</param>
+	/// <param name="format">テキストフォーマット</param>
+	void WriteWords(const D3DXVECTOR2 topLeft, const TCHAR* fontKey, int format);
+
+	/// <summary>
+	/// 文字列をフォントで描画
+	/// </summary>
+	/// <param name="topLeft">左上の位置</param>
+	/// <param name="fontKey">フォントキー</param>
+	/// <param name="format">テキストフォーマット</param>
+	/// <param name="color">文字の色</param>
+	void WriteWords(const D3DXVECTOR2 topLeft, const TCHAR* fontKey, int format, const gameframework::Color& color);
+
+	/// <summary>
+	/// 変数から文字列の設定
+	/// </summary>
+	/// <param name="words">文字列</param>
+	/// <param name="variable">設定したい変数</param>
+	template<typename BattleTmp>inline void SetString(const TCHAR* words, const BattleTmp variable)
+	{
+		const int ARRAY_SIZE = 128;
+		TCHAR str[ARRAY_SIZE];
+		_stprintf_s(str, ARRAY_SIZE, words, variable);
+		SetString(str);
+	};
+
+	/// <summary>
+	/// 文字列の設定
+	/// </summary>
+	/// <param name="words"></param>
+	void SetString(const TCHAR* words);
+private:
+
+	gameframework::RectSize m_PolygonSize;
+
+	gameframework::Vertices* m_pRect = nullptr;
+	gameframework::GameFramework& m_rGameFramework = gameframework::GameFramework::GetRef();
+	gameframework::Stream* m_pStream = nullptr;
+
+
+};
+}
+#endif

--- a/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Cemetery/Cemetery.cpp
+++ b/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Cemetery/Cemetery.cpp
@@ -1,0 +1,52 @@
+﻿#include "Cemetery.h"
+
+using namespace gameframework;
+namespace summonersaster
+{
+
+Cemetery::Cemetery()
+{
+}
+
+Cemetery::~Cemetery()
+{
+}
+
+void Cemetery::Render()
+{
+	if (0 == m_Cards.size()) return;
+#ifdef _DEBUG
+
+	for (int i = 0; i < m_Cards.size(); ++i)
+	{
+		SetString(L"%d", m_Cards[i]->ID);
+		WriteWords(D3DXVECTOR2(i * (Card::DEBUG_WORD_WIGTH * 1.5f) + Card::DEBUG_WORD_WIGTH * 2, 300.f), _T("Debug_str"), DT_RIGHT, (0xFF00FF00));
+		
+	}
+#endif
+	SetVertex(D3DXVECTOR3(m_TexturCenter.x, m_TexturCenter.y, 0.0f), RectSize(200.f, 260.f), Color());
+	DrowTexture(_T("TEAM_LOGO"));
+
+	SetString(L"%d", static_cast<int>(m_Cards.size()));
+	WriteWords(D3DXVECTOR2(m_TexturCenter.x + 150.f, m_TexturCenter.y), _T("INPUT_PROMPT"), DT_RIGHT, (0xFF00FF00));
+
+
+}
+
+void Cemetery::Destroy()
+{
+	//外部からの読み込み時に動的確保するため
+	for (auto card : m_Cards)
+	{
+		delete card;
+	}
+	m_Cards.clear();
+}
+
+void Cemetery::PreserveCard(Card* card)
+{
+	if (nullptr == card) return;
+
+	m_Cards.emplace_back(card);
+}
+}

--- a/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Cemetery/Cemetery.h
+++ b/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Cemetery/Cemetery.h
@@ -1,0 +1,38 @@
+﻿#ifndef CEMETERY_H
+#define CEMETERY_H
+
+#include <vector>
+#include "Scene/BattleScene/BattleObject.h"
+
+//仮カードクラス
+class Card;
+namespace summonersaster
+{
+
+class Cemetery :public BattleObject
+{
+public:
+	Cemetery();
+	~Cemetery();
+	void Render();
+	void Destroy();
+
+	/// <summary>
+	/// カードを受ける
+	/// </summary>
+	/// <param name="card">もらうカードクラスポインタ</param>
+	void PreserveCard(Card* card);
+
+	int GetQuantites()
+	{
+		return static_cast<int>(m_Cards.size());
+	}
+
+private:
+	std::vector<Card*> m_Cards;
+
+	D3DXVECTOR2 m_TexturCenter = { 1300.0f,300.0f };
+
+};
+}
+#endif

--- a/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Deck/Deck.cpp
+++ b/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Deck/Deck.cpp
@@ -1,0 +1,80 @@
+﻿#include "Deck.h"
+#include <random>
+#include <algorithm>
+
+using namespace gameframework;
+namespace summonersaster
+{
+
+Deck::Deck(const char* deckName):DECK_NAME(deckName)
+{
+}
+
+Deck::~Deck()
+{
+}
+
+void Deck::Render()
+{
+#ifdef _DEBUG
+	for (int i = 0; i < m_Cards.size(); ++i)
+	{
+		SetString(L"%d", m_Cards[i]->ID);
+		WriteWords(D3DXVECTOR2(i * (Card::DEBUG_WORD_WIGTH * 1.5f) + Card::DEBUG_WORD_WIGTH * 2, 800.f), _T("Debug_str"), DT_RIGHT, (0xFFAAAAAA));
+	}
+#endif
+	Color color;
+	if (0 == m_Cards.size())
+		color = (255, 255, 0, 0);
+	
+	SetVertex(D3DXVECTOR3(m_TexturCenter.x, m_TexturCenter.y, 0.0f), RectSize(200.f, 260.f),color);
+	DrowTexture(_T("TEAM_LOGO"));
+
+	SetString(L"%d", static_cast<int>(m_Cards.size()));
+	WriteWords(D3DXVECTOR2(m_TexturCenter.x + 150.f, m_TexturCenter.y), _T("INPUT_PROMPT"), DT_RIGHT, (0xFFAAAAAA));
+
+}
+
+void Deck::Destroy()
+{
+	//外部からの読み込み時に動的確保するため
+	for (auto card : m_Cards)
+	{
+		delete card;
+	}
+	m_Cards.clear();
+}
+
+void Deck::Load()
+{
+	m_Cards.resize(LIMIT_CAPACITY);
+	for (int i=0;i<LIMIT_CAPACITY;++i)
+	{
+		//m_Cards[i] = new Card(i);
+	}
+	//デッキ読み込み
+	//読み込み枚数が規定枚数でない場合エラーを吐かせる
+}
+
+void Deck::Shuffle()
+{
+	//乱数生成してシャッフルする
+	std::random_device seed_gen;
+	std::mt19937 engine(seed_gen());
+	std::shuffle(m_Cards.begin(), m_Cards.end(), engine);
+}
+
+void Deck::AddCard(Card* card)
+{
+	m_Cards.emplace_back(card);
+}
+
+Card* Deck::SendCard()
+{
+	if (0 == m_Cards.size()) return nullptr;
+	Card* sendCard = m_Cards.back();
+	m_Cards.back() = nullptr;
+	m_Cards.pop_back();
+	return sendCard;
+}
+}

--- a/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Deck/Deck.h
+++ b/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Deck/Deck.h
@@ -1,0 +1,56 @@
+﻿#ifndef DECK_H
+#define DECK_H
+
+#include <vector>
+#include "Scene/BattleScene/BattleObject.h"
+
+//仮カードクラス
+class Card;
+namespace summonersaster
+{
+
+class Deck :public BattleObject
+{
+public:
+	Deck(const char* deckName);
+	~Deck();
+	void Render();
+	void Destroy();
+
+	/// <summary>
+	/// デッキのロード
+	/// </summary>
+	void Load();
+
+	/// <summary>
+	/// シャッフル
+	/// </summary>
+	void Shuffle();
+
+	/// <summary>
+	/// デッキ末尾にカード追加
+	/// </summary>
+	/// <param name="card">もらうカードクラスポインタ</param>
+	void AddCard(Card* card);
+
+	/// <summary>
+	/// 末尾からカードを送る
+	/// </summary>
+	/// <returns>送るカードクラスポインタ</returns>
+	Card* SendCard();
+
+	int GetQuantites()
+	{
+		return static_cast<int>(m_Cards.size());
+	}
+private:
+	std::vector<Card*> m_Cards;
+	const int LIMIT_CAPACITY = 40;
+	const char* DECK_NAME;
+
+
+	D3DXVECTOR2 m_TexturCenter = { 1300.0f,700.0f };
+
+};
+}
+#endif

--- a/Summoners-Aster/SceneSwitcher/Scene/BattleScene/HP/HP.cpp
+++ b/Summoners-Aster/SceneSwitcher/Scene/BattleScene/HP/HP.cpp
@@ -1,0 +1,38 @@
+﻿#include "HP.h"
+
+namespace summonersaster
+{
+
+
+HP::HP()
+{
+}
+
+
+HP::~HP()
+{
+}
+
+void HP::Render()
+{
+}
+
+void HP::Damaged(unsigned int damage)
+{
+	m_Hp -= damage;
+	if (m_Hp < 0) 
+	{
+		m_Hp = 0;
+		//死亡通知を流す
+	}
+}
+
+void HP::Recover(unsigned int heal)
+{
+	m_Hp += heal;
+	if (m_Hp > MAX_CAPACITY) 
+	{
+		m_Hp = MAX_CAPACITY;
+	}
+}
+}

--- a/Summoners-Aster/SceneSwitcher/Scene/BattleScene/HP/HP.h
+++ b/Summoners-Aster/SceneSwitcher/Scene/BattleScene/HP/HP.h
@@ -1,0 +1,37 @@
+﻿#ifndef HP_H
+#define HP_H
+namespace summonersaster
+{
+
+class HP
+{
+public:
+	HP();
+	~HP();
+	void Render();
+
+	/// <summary>
+	/// HPを減らす
+	/// </summary>
+	/// <param name="damage">減らす量</param>
+	void Damaged(unsigned int damage);
+
+	/// <summary>
+	/// HPを増やす
+	/// </summary>
+	/// <param name="heal">増やす量</param>
+	/// <remarks>初期値よりも増えない</remarks>
+	void Recover(unsigned int heal);
+	unsigned int GetRemain() {
+		return m_Hp;
+	}
+private:
+	const unsigned int MAX_CAPACITY = 10;//仮数値
+	unsigned int m_Hp = MAX_CAPACITY;
+	HP(HP& hP) = delete;
+
+	HP& operator=(HP& hP) = delete;
+
+};
+}
+#endif

--- a/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Hand/Hand.cpp
+++ b/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Hand/Hand.cpp
@@ -1,0 +1,70 @@
+﻿#include "Hand.h"
+
+using namespace gameframework;
+
+namespace summonersaster
+{
+
+Hand::Hand()
+{
+}
+
+
+Hand::~Hand()
+{
+	Destroy();
+}
+
+
+void Hand::Render()
+{
+	for (int i = 0; i < m_Cards.size(); ++i)
+	{
+		SetVertex(D3DXVECTOR3(m_TexturCenter.x + 50 * i, m_TexturCenter.y, 0.0f),RectSize(200.f, 260.f),Color(255, i * 50 + 50, i * 50 + 50, i * 50 + 50));
+		DrowTexture(_T("TEAM_LOGO"));
+		SetString(L"%d", static_cast<int>(m_Cards.size()));
+		WriteWords(D3DXVECTOR2(m_TexturCenter.x - 50.f , m_TexturCenter.y),_T("INPUT_PROMPT"), DT_CENTER);
+
+#ifdef _DEBUG
+		SetString(L"%d", m_Cards[i]->ID);
+		WriteWords(D3DXVECTOR2(i * (Card::DEBUG_WORD_WIGTH * 1.5f) + Card::DEBUG_WORD_WIGTH * 2, 700.f),_T("Debug_str"), DT_RIGHT,(0xFF0000FF));
+#endif
+
+	}
+}
+
+void Hand::Destroy()
+{
+	//外部からの読み込み時に動的確保するため
+	for (auto card : m_Cards)
+	{
+		delete card;
+	}
+	m_Cards.clear();
+
+}
+
+Hand::RESULT Hand::AddCard(Card* card)
+{
+	if (nullptr == card)
+	{
+		//死亡通知
+		return DEAD;
+	}
+	m_Cards.emplace_back(card);
+	if (MAX_CAPACITY < m_Cards.size())
+	{
+		return FLOOD;
+	}
+	return SUCCESS;
+}
+
+Card* Hand::SendCard(unsigned int handNum)
+{
+	if (handNum >= m_Cards.size()) return nullptr;
+	Card* sendCard = m_Cards[handNum];
+	m_Cards[handNum] = nullptr;
+	m_Cards.erase(m_Cards.begin() + handNum);
+	return sendCard;
+}
+}

--- a/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Hand/Hand.h
+++ b/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Hand/Hand.h
@@ -1,0 +1,51 @@
+﻿#ifndef HAND_H
+#define HAND_H
+
+#include <vector>
+#include "Scene/BattleScene/BattleObject.h"
+//仮カードクラス
+class Card;
+namespace summonersaster
+{
+
+class Hand :public BattleObject
+{
+public:
+	enum RESULT
+	{
+		SUCCESS,
+		FLOOD,
+		DEAD,
+	};
+
+	Hand();
+	~Hand();
+	void Render();
+	void Destroy();
+	/// <summary>
+	/// カードの追加
+	/// </summary>
+	/// <param name="card">追加するカードクラスポインタ</param>
+	/// <returns>ドロー結果</returns>
+	RESULT AddCard(Card* card);
+
+	int GetQuantites()
+	{
+		return static_cast<int>(m_Cards.size());
+	}
+
+	/// <summary>
+	/// カードを送る
+	/// </summary>
+	/// <param name="handNum">手札番号</param>
+	/// <returns>送るカードクラスポインタ</returns>
+	Card* SendCard(unsigned int handNum);
+private:
+	std::vector<Card*> m_Cards;
+	const unsigned int MAX_CAPACITY = 9;
+
+	D3DXVECTOR2 m_TexturCenter = { 500.0f,600.0f };
+
+};
+}
+#endif

--- a/Summoners-Aster/SceneSwitcher/Scene/BattleScene/MP/MP.cpp
+++ b/Summoners-Aster/SceneSwitcher/Scene/BattleScene/MP/MP.cpp
@@ -1,0 +1,38 @@
+﻿#include "MP.h"
+
+
+namespace summonersaster
+{
+
+MP::MP()
+{
+}
+
+
+MP::~MP()
+{
+}
+
+void MP::Render()
+{
+}
+
+void MP::IncreaseCapacity()
+{
+	if (m_Capacity == MAX_CAPACITY) return;
+	++m_Capacity;
+}
+
+bool MP::Paid(const unsigned int paidMp)
+{
+	if (paidMp > m_UsablePoint) return false;
+	m_UsablePoint -= paidMp;
+	return true;
+}
+
+void MP::RenewUsablePoints()
+{
+	m_UsablePoint = m_Capacity;
+}
+
+}

--- a/Summoners-Aster/SceneSwitcher/Scene/BattleScene/MP/MP.h
+++ b/Summoners-Aster/SceneSwitcher/Scene/BattleScene/MP/MP.h
@@ -1,0 +1,49 @@
+﻿#ifndef MP_H
+#define MP_H
+namespace summonersaster
+{
+
+class MP
+{
+public:
+	MP();
+	~MP();
+	void Render();
+
+	unsigned int GetUsablePoint() const
+	{
+		return m_UsablePoint;
+	}
+	unsigned int GetCapacity() const
+	{
+		return m_Capacity;
+	}
+
+	/// <summary>
+	/// 最大値を増やす
+	/// </summary>
+	/// <remarks>増加最大値は<seealso cref="MAX_CAPACITY"/></remarks>
+	void IncreaseCapacity();
+
+	/// <summary>
+	/// 値を減らす
+	/// </summary>
+	/// <param name="paidMp">減らす量</param>
+	bool Paid(const unsigned int paidMp);
+
+	/// <summary>
+	/// 使用可能ポイントを今の容量で更新する
+	/// </summary>
+	void RenewUsablePoints();
+private:
+	const unsigned int MAX_CAPACITY = 10;
+	unsigned int m_UsablePoint = 0;
+	unsigned int m_Capacity = 0;
+
+	MP(MP& mP) = delete;
+
+	MP& operator=(MP& mP) = delete;
+
+};
+}
+#endif

--- a/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Player/BattlePlayer.cpp
+++ b/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Player/BattlePlayer.cpp
@@ -1,0 +1,199 @@
+﻿#include "BattlePlayer.h"
+
+using namespace gameframework;
+
+
+namespace summonersaster
+{
+
+
+BattlePlayer::BattlePlayer(const char* deckName):USE_DECK_NAME(deckName),m_RotationTickets(3)
+
+{
+	Initialize();
+}
+
+
+BattlePlayer::~BattlePlayer()
+{
+	Destroy();
+}
+
+void BattlePlayer::Initialize()
+{
+
+	m_pHand = new Hand();
+	m_pDeck = new Deck(USE_DECK_NAME);
+	m_pDeck->Load();
+	m_pCemetery = new Cemetery();
+	m_pHP = new HP();
+	m_pMP = new MP();
+
+	GameFrameworkFactory::Create(&m_pRect);
+	m_rGameFramework.CreateTexture(_T("TEAM_LOGO"), _T("Textures/SINGULARITY.png"));
+	m_rGameFramework.CreateFont(_T("INPUT_PROMPT"), RectSize(30, 50), _T("IPAex明朝"));
+	m_rGameFramework.CreateFont(_T("Debug_str"), RectSize(Card::DEBUG_WORD_WIGTH*0.5, Card::DEBUG_WORD_WIGTH), _T("IPAex明朝"));
+
+	Shuffle();
+	DrawCard();
+	DrawCard();
+	DrawCard();
+
+}
+
+void BattlePlayer::Destroy()
+{	
+	delete m_pHand;
+	delete m_pDeck;
+	delete m_pCemetery;
+	delete m_pHP;
+	delete m_pMP;
+
+	delete m_pRect;
+	m_rGameFramework.ReleaseTexture(_T("TEAM_LOGO"));
+	m_rGameFramework.ReleaseFont(_T("INPUT_PROMPT"));
+	m_rGameFramework.ReleaseFont(_T("Debug_str"));
+
+}
+
+bool BattlePlayer::Update(const char* phase)
+{
+	GameFramework& rGameFramework = GameFramework::CreateAndGetRef();
+
+	if (rGameFramework.KeyboardIsPressed(DIK_G))
+	{
+		DrawCard();
+	}
+	if (rGameFramework.KeyboardIsPressed(DIK_S))
+	{
+		Shuffle();
+	}
+	if (rGameFramework.KeyboardIsPressed(DIK_M))
+	{
+		Mulligan();
+	}
+	if (rGameFramework.KeyboardIsPressed(DIK_P))
+	{
+		SendCardFromDeckToGraveyard();
+	}
+	if (rGameFramework.KeyboardIsPressed(DIK_1))
+	{
+		m_pCemetery->PreserveCard(m_pHand->SendCard(0));
+	}
+	if (rGameFramework.KeyboardIsPressed(DIK_2))
+	{
+		m_pCemetery->PreserveCard(m_pHand->SendCard(1));
+	}
+	if (rGameFramework.KeyboardIsPressed(DIK_3))
+	{
+		m_pCemetery->PreserveCard(m_pHand->SendCard(2));
+	}
+	if (rGameFramework.KeyboardIsPressed(DIK_4))
+	{
+		m_pCemetery->PreserveCard(m_pHand->SendCard(3));
+	}
+	if (rGameFramework.KeyboardIsPressed(DIK_5))
+	{
+		m_pCemetery->PreserveCard(m_pHand->SendCard(4));
+	}
+	if (rGameFramework.KeyboardIsPressed(DIK_6))
+	{
+		m_pCemetery->PreserveCard(m_pHand->SendCard(5));
+	}
+	if (rGameFramework.KeyboardIsPressed(DIK_7))
+	{
+		m_pCemetery->PreserveCard(m_pHand->SendCard(6));
+	}
+	if (rGameFramework.KeyboardIsPressed(DIK_8))
+	{
+		m_pCemetery->PreserveCard(m_pHand->SendCard(7));
+	}
+	if (rGameFramework.KeyboardIsPressed(DIK_9))
+	{
+		m_pCemetery->PreserveCard(m_pHand->SendCard(8));
+	}
+
+	return false;//仮
+}
+
+void BattlePlayer::Render()
+{
+	m_pRect->GetCenter() = { m_TexturCenter.x, m_TexturCenter.y, 0.0f };
+	m_pRect->SetSize(RectSize(500.f, 300.f));
+
+	m_pRect->Render(m_rGameFramework.GetTexture(_T("TEAM_LOGO")));
+	
+	m_pDeck->Render();
+	m_pCemetery->Render();
+	m_pHand->Render();
+}
+
+bool BattlePlayer::RotateField()
+{
+	if(0==m_RotationTickets) return false;
+	--m_RotationTickets;
+	return true;
+}
+
+void BattlePlayer::Damaged(unsigned int damage)
+{
+	m_pHP->Damaged(damage);
+}
+void BattlePlayer::Recover(unsigned int heal)
+{
+	m_pHP->Recover(heal);
+}
+
+void BattlePlayer::DrawCard()
+{
+	Hand::RESULT drawResult;
+	if (Hand::FLOOD == (drawResult = m_pHand->AddCard(m_pDeck->SendCard())))
+	{
+		m_pCemetery->PreserveCard(m_pHand->SendCard(9));
+	}
+	if (Hand::DEAD == drawResult)
+	{
+
+	}
+}
+
+void BattlePlayer::SendCardFromHandToGraveyard(unsigned int handNum)
+{
+	m_pCemetery->PreserveCard(m_pHand->SendCard(handNum));
+}
+
+void BattlePlayer::SendCardFromDeckToGraveyard()
+{
+	m_pCemetery->PreserveCard(m_pDeck->SendCard());
+}
+
+void BattlePlayer::SendToGraveyard(Card* card)
+{
+	m_pCemetery->PreserveCard(card);
+}
+
+Card* BattlePlayer::SendFromHand(unsigned int handNum)
+{
+	return m_pHand->SendCard(handNum);
+}
+
+void BattlePlayer::Shuffle()
+{
+	m_pDeck->Shuffle();
+}
+
+void BattlePlayer::Mulligan()
+{
+	size_t handQuantities = m_pHand->GetQuantites();
+	while(m_pHand->GetQuantites())
+	{
+		m_pDeck->AddCard(m_pHand->SendCard(0));
+	}
+	m_pDeck->Shuffle();
+	for (int i = 0; i < handQuantities; ++i)
+	{
+		m_pHand->AddCard(m_pDeck->SendCard());
+	}
+}
+
+}

--- a/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Player/BattlePlayer.h
+++ b/Summoners-Aster/SceneSwitcher/Scene/BattleScene/Player/BattlePlayer.h
@@ -1,0 +1,104 @@
+﻿#ifndef BATTLE_PLAYER_H
+#define BATTLE_PLAYER_H
+
+#include <GameFramework.h>
+
+#include "Scene/BattleScene/Deck/Deck.h"
+#include "Scene/BattleScene/Hand/Hand.h"
+#include "Scene/BattleScene/Cemetery/Cemetery.h"
+#include "Scene/BattleScene/HP/HP.h"
+#include "Scene/BattleScene/MP/MP.h"
+
+namespace summonersaster
+{
+
+class BattlePlayer
+{
+public:
+	BattlePlayer(const char* deckName);
+	~BattlePlayer();
+
+
+
+	void Initialize();
+	void Destroy();
+	bool Update(const char* phase);
+	void Render();
+
+	/// <summary>
+	/// デッキの末尾からカードを手札に入れる
+	/// </summary>
+	void DrawCard();
+
+	/// <summary>
+	/// 手札から指定のカードを墓地に送る
+	/// </summary>
+	/// <param name="handNum">送る手札番号</param>
+	void SendCardFromHandToGraveyard(unsigned int handNum);
+
+	/// <summary>
+	/// デッキの末尾からカードを墓地に送る
+	/// </summary>
+	void SendCardFromDeckToGraveyard();
+
+	/// <summary>
+	/// カードを墓地に送る
+	/// </summary>
+	/// <param name="card">送りたいカードクラスポインタ</param>
+	void SendToGraveyard(Card* card);
+
+	/// <summary>
+	/// 手札からカードを送る
+	/// </summary>
+	/// <param name="handNum">送る手札番号</param>
+	/// <returns>送られるカードクラスポインタ</returns>
+	Card* SendFromHand(unsigned int handNum);
+
+	/// <summary>
+	/// デッキをシャッフルする
+	/// </summary>
+	void Shuffle();
+
+	/// <summary>
+	/// 所持している手札をデッキに戻して同枚数引く
+	/// </summary>
+	void Mulligan();
+
+	/// <summary>
+	/// 回転権を消費する
+	/// </summary>
+	/// <returns>消費できたらTRUE、できなければFALSEL</returns>
+	bool RotateField();
+
+	/// <summary>
+	/// HPを減らす
+	/// </summary>
+	/// <param name="damage">減らす量</param>
+	void Damaged(unsigned int damage);
+
+	/// <summary>
+	/// HPを増やす
+	/// </summary>
+	/// <param name="heal">増やす量</param>
+	/// <remarks>初期値よりも増えない</remarks>
+	void Recover(unsigned int heal);
+private:
+	Hand* m_pHand = nullptr;
+	Deck* m_pDeck = nullptr;
+	Cemetery* m_pCemetery = nullptr;
+	HP* m_pHP = nullptr;
+	MP* m_pMP = nullptr;
+
+	const char* USE_DECK_NAME;
+
+	unsigned int m_RotationTickets;
+
+	D3DXVECTOR2 m_TexturCenter = { 800.0f,700.0f };
+	gameframework::RectSize m_PolygonSize;
+
+	gameframework::Vertices* m_pRect = nullptr;
+	gameframework::GameFramework& m_rGameFramework = gameframework::GameFramework::GetRef();
+
+};
+}
+#endif

--- a/Summoners-Aster/Summoners-Aster.vcxproj
+++ b/Summoners-Aster/Summoners-Aster.vcxproj
@@ -26,6 +26,13 @@
     <ClCompile Include="ObjectIntegrator\Object\Task.cpp" />
     <ClCompile Include="ObjectIntegrator\TaskScheduler.cpp" />
     <ClCompile Include="SceneSwitcher\SceneSwitcher.cpp" />
+    <ClCompile Include="SceneSwitcher\Scene\BattleScene\BattleObject.cpp" />
+    <ClCompile Include="SceneSwitcher\Scene\BattleScene\Cemetery\Cemetery.cpp" />
+    <ClCompile Include="SceneSwitcher\Scene\BattleScene\Deck\Deck.cpp" />
+    <ClCompile Include="SceneSwitcher\Scene\BattleScene\Hand\Hand.cpp" />
+    <ClCompile Include="SceneSwitcher\Scene\BattleScene\HP\HP.cpp" />
+    <ClCompile Include="SceneSwitcher\Scene\BattleScene\MP\MP.cpp" />
+    <ClCompile Include="SceneSwitcher\Scene\BattleScene\Player\BattlePlayer.cpp" />
     <ClCompile Include="SceneSwitcher\Scene\HomeScene\ConnectButton.cpp" />
     <ClCompile Include="SceneSwitcher\Scene\HomeScene\CPUButton.cpp" />
     <ClCompile Include="SceneSwitcher\Scene\HomeScene\DeckButton.cpp" />
@@ -67,6 +74,13 @@
     <ClInclude Include="ObjectIntegrator\Object\Task.h" />
     <ClInclude Include="ObjectIntegrator\TaskScheduler.h" />
     <ClInclude Include="SceneSwitcher\SceneSwitcher.h" />
+    <ClInclude Include="SceneSwitcher\Scene\BattleScene\BattleObject.h" />
+    <ClInclude Include="SceneSwitcher\Scene\BattleScene\Cemetery\Cemetery.h" />
+    <ClInclude Include="SceneSwitcher\Scene\BattleScene\Deck\Deck.h" />
+    <ClInclude Include="SceneSwitcher\Scene\BattleScene\Hand\Hand.h" />
+    <ClInclude Include="SceneSwitcher\Scene\BattleScene\HP\HP.h" />
+    <ClInclude Include="SceneSwitcher\Scene\BattleScene\MP\MP.h" />
+    <ClInclude Include="SceneSwitcher\Scene\BattleScene\Player\BattlePlayer.h" />
     <ClInclude Include="SceneSwitcher\Scene\HomeScene\ConnectButton.h" />
     <ClInclude Include="SceneSwitcher\Scene\HomeScene\CPUButton.h" />
     <ClInclude Include="SceneSwitcher\Scene\HomeScene\DeckButton.h" />
@@ -163,7 +177,7 @@
     <LibraryPath>$(DXSDK_DIR)Lib\x86;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>$(DXSDK_DIR)Include;$(ProjectDir)GameFramework\Include;$(IncludePath)</IncludePath>
+    <IncludePath>$(DXSDK_DIR)Include;$(ProjectDir)GameFramework\Include;$(ProjectDir);$(IncludePath)</IncludePath>
     <LibraryPath>$(DXSDK_DIR)Lib\x64;$(ProjectDir)GameFramework\Lib\Debug;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/Summoners-Aster/Summoners-Aster.vcxproj.filters
+++ b/Summoners-Aster/Summoners-Aster.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="リソース ファイル">
@@ -46,6 +46,27 @@
     </Filter>
     <Filter Include="SceneSwitcher\Scene\MainScene\Step\PlayerInformationRenderingStep">
       <UniqueIdentifier>{560267b3-fee4-4b98-b214-bf9cfe200206}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="SceneSwitcher\Scene\BattleScene">
+      <UniqueIdentifier>{471de5b6-2536-417d-92bc-1e04c7239923}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="SceneSwitcher\Scene\BattleScene\Deck">
+      <UniqueIdentifier>{dabd720e-8425-473a-a1a2-f152663b7ac5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="SceneSwitcher\Scene\BattleScene\Hand">
+      <UniqueIdentifier>{73c81bd9-6d3e-4528-ad4b-75c52fcc0fa2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="SceneSwitcher\Scene\BattleScene\BattlePlayer">
+      <UniqueIdentifier>{045a0001-d10c-4ad1-a965-9e534eb99cf6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="SceneSwitcher\Scene\BattleScene\Cemetery">
+      <UniqueIdentifier>{46579633-df13-42cc-bcdd-f177eae0b80b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="SceneSwitcher\Scene\BattleScene\HP">
+      <UniqueIdentifier>{4117ba4e-a27c-4c64-9da6-4ed705250692}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="SceneSwitcher\Scene\BattleScene\MP">
+      <UniqueIdentifier>{b41754a4-e88d-43fc-9e1d-5f7871e29a50}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -172,6 +193,27 @@
     <ClInclude Include="SceneSwitcher\Scene\MainScene\Step\PlayersInformationRenderingStep\PlayersInformationRenderingStep.h">
       <Filter>SceneSwitcher\Scene\MainScene\Step\PlayerInformationRenderingStep</Filter>
     </ClInclude>
+    <ClInclude Include="SceneSwitcher\Scene\BattleScene\Deck\Deck.h">
+      <Filter>SceneSwitcher\Scene\BattleScene\Deck</Filter>
+    </ClInclude>
+    <ClInclude Include="SceneSwitcher\Scene\BattleScene\Hand\Hand.h">
+      <Filter>SceneSwitcher\Scene\BattleScene\Hand</Filter>
+    </ClInclude>
+    <ClInclude Include="SceneSwitcher\Scene\BattleScene\Player\BattlePlayer.h">
+      <Filter>SceneSwitcher\Scene\BattleScene\BattlePlayer</Filter>
+    </ClInclude>
+    <ClInclude Include="SceneSwitcher\Scene\BattleScene\Cemetery\Cemetery.h">
+      <Filter>SceneSwitcher\Scene\BattleScene\Cemetery</Filter>
+    </ClInclude>
+    <ClInclude Include="SceneSwitcher\Scene\BattleScene\HP\HP.h">
+      <Filter>SceneSwitcher\Scene\BattleScene\HP</Filter>
+    </ClInclude>
+    <ClInclude Include="SceneSwitcher\Scene\BattleScene\MP\MP.h">
+      <Filter>SceneSwitcher\Scene\BattleScene\MP</Filter>
+    </ClInclude>
+    <ClInclude Include="SceneSwitcher\Scene\BattleScene\BattleObject.h">
+      <Filter>SceneSwitcher\Scene\BattleScene</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="SceneSwitcher\SceneSwitcher.cpp">
@@ -293,6 +335,27 @@
     </ClCompile>
     <ClCompile Include="SceneSwitcher\Scene\MainScene\Step\PlayersInformationRenderingStep\PlayersInformationRenderingStep.cpp">
       <Filter>SceneSwitcher\Scene\MainScene\Step\PlayerInformationRenderingStep</Filter>
+    </ClCompile>
+    <ClCompile Include="SceneSwitcher\Scene\BattleScene\Deck\Deck.cpp">
+      <Filter>SceneSwitcher\Scene\BattleScene\Deck</Filter>
+    </ClCompile>
+    <ClCompile Include="SceneSwitcher\Scene\BattleScene\Hand\Hand.cpp">
+      <Filter>SceneSwitcher\Scene\BattleScene\Hand</Filter>
+    </ClCompile>
+    <ClCompile Include="SceneSwitcher\Scene\BattleScene\Player\BattlePlayer.cpp">
+      <Filter>SceneSwitcher\Scene\BattleScene\BattlePlayer</Filter>
+    </ClCompile>
+    <ClCompile Include="SceneSwitcher\Scene\BattleScene\Cemetery\Cemetery.cpp">
+      <Filter>SceneSwitcher\Scene\BattleScene\Cemetery</Filter>
+    </ClCompile>
+    <ClCompile Include="SceneSwitcher\Scene\BattleScene\HP\HP.cpp">
+      <Filter>SceneSwitcher\Scene\BattleScene\HP</Filter>
+    </ClCompile>
+    <ClCompile Include="SceneSwitcher\Scene\BattleScene\MP\MP.cpp">
+      <Filter>SceneSwitcher\Scene\BattleScene\MP</Filter>
+    </ClCompile>
+    <ClCompile Include="SceneSwitcher\Scene\BattleScene\BattleObject.cpp">
+      <Filter>SceneSwitcher\Scene\BattleScene</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## 元Issue
Refs #53

## 変更内容
- [x] プレイヤー、デッキ、手札、墓地、HP、MPクラス作成
- [x] デッキ、手札、墓地へのカード移動
- [x] HP、MPの増減処理
~~デッキ、手札、場、墓地について公開情報提示~~
~~マウスドラッグによるカード移動~~

