### PR TITLE
[#100] カード効果を複数所持する構造の実装

### DIFF
--- a/Summoners-Aster/Card/Ability/AbilityExecutor.cpp
+++ b/Summoners-Aster/Card/Ability/AbilityExecutor.cpp
@@ -15,9 +15,9 @@ AbilityExecutor::~AbilityExecutor()
 {
 }
 
-void AbilityExecutor::Execute(Card* card)
+void AbilityExecutor::Execute(Card* card, Ability::Execute executeName)
 {
-	switch (card->GetExcute())
+	switch (executeName)
 	{
 	case Ability::Execute::DRAWCARD:
 		Players::GetPlayer(card->Owner())->DrawCard();
@@ -38,7 +38,7 @@ void AbilityExecutor::Execute(Card* card)
 	}
 }
 
-void AbilityExecutor::Execute(FollowerData* followerData)
+void AbilityExecutor::Execute(FollowerData* followerData, Ability::Execute executeName)
 {
 	GameFramework& rGameFramework = GameFramework::CreateAndGetRef();
 	rGameFramework.OneShotSimultaneous(L"ABILITY");
@@ -47,7 +47,7 @@ void AbilityExecutor::Execute(FollowerData* followerData)
 			followerData->m_pVertices->GetCenter(),
 			20));
 
-	switch (followerData->m_pFollower->GetExcute())
+	switch (executeName)
 	{
 	case Ability::Execute::DRAWCARD:
 		Players::GetPlayer(followerData->m_pFollower->Owner())->DrawCard();

--- a/Summoners-Aster/Card/Ability/AbilityExecutor.h
+++ b/Summoners-Aster/Card/Ability/AbilityExecutor.h
@@ -19,13 +19,13 @@ public:
 	/// 効果実行
 	/// </summary>
 	/// <param name="card">効果を実行するカード</param>
-	static void Execute(Card* card);
+	static void Execute(Card* card, Ability::Execute executeName);
 
 	/// <summary>
 	/// 効果実行
 	/// </summary>
-	/// <param name="followerData">効果を実行するフォロワーデータ</param>
-	static void Execute(FollowerData* followerData);
+	/// <param name="">効果の名前</param>
+	static void Execute(FollowerData* followerData, Ability::Execute executeName);
 };
 }
 #endif

--- a/Summoners-Aster/Card/Ability/AbilityTextController.cpp
+++ b/Summoners-Aster/Card/Ability/AbilityTextController.cpp
@@ -73,9 +73,18 @@ namespace summonersaster
 	void AbilityTextController::RenderAbilityText(const tstring& cardName, const D3DXVECTOR2& topLeft, const LPFONT& pFont)
 	{
 		m_pAbilityStream->SetTopLeft(topLeft);
-		*m_pAbilityStream = GetActivationText(cardName);
-		*m_pAbilityStream += gameframework::algorithm::Tertiary(*m_pAbilityStream == _T(""), _T(""), _T("\n"));
-		*m_pAbilityStream += GetExecuteText(cardName);
+
+		*m_pAbilityStream = _T("");
+
+		std::vector<Ability> abilities = m_rCardFolder[cardName].Abilities();
+		//カード効果全てを文字列に詰める
+		for (auto ability : abilities)
+		{
+			*m_pAbilityStream += GetActivationText(ability.activationEvent, cardName);
+			*m_pAbilityStream += gameframework::algorithm::Tertiary(*m_pAbilityStream == _T(""), _T(""), _T("\n"));
+			*m_pAbilityStream += GetExecuteText(ability.execute, cardName);
+			*m_pAbilityStream += gameframework::algorithm::Tertiary(*m_pAbilityStream == _T(""), _T(""), _T("\n\n"));
+		}
 
 		m_pAbilityStream->Render(pFont, DT_LEFT);
 		RenderCardStateText();
@@ -258,9 +267,9 @@ namespace summonersaster
 		m_renderingCardInformation.m_isMoved = followerData.m_isMoved;
 	}
 
-	const TCHAR* AbilityTextController::GetActivationText(const tstring& cardName)
+	const TCHAR* AbilityTextController::GetActivationText(ActivationEvent eventName, const tstring& cardName)
 	{
-		switch (m_rCardFolder[cardName].GetActivationEvent())
+		switch (eventName)
 		{
 		case ActivationEvent::NONE:
 			return _T("");
@@ -320,9 +329,9 @@ namespace summonersaster
 		return nullptr;
 	}
 
-	const TCHAR* AbilityTextController::GetExecuteText(const tstring& cardName)
+	const TCHAR* AbilityTextController::GetExecuteText(Execute executeName, const tstring& cardName)
 	{
-		switch (m_rCardFolder[cardName].GetExcute())
+		switch (executeName)
 		{
 		case Execute::DRAWCARD:
 			return _T("カードを一枚ドローする。");

--- a/Summoners-Aster/Card/Ability/AbilityTextController.h
+++ b/Summoners-Aster/Card/Ability/AbilityTextController.h
@@ -148,9 +148,9 @@ namespace summonersaster
 
 		void SubstituteFollowerData(const FollowerData& followerData);
 
-		const TCHAR* GetActivationText(const tstring& cardName);
+		const TCHAR* GetActivationText(ActivationEvent eventName, const tstring& cardName);
 
-		const TCHAR* GetExecuteText(const tstring& cardName);
+		const TCHAR* GetExecuteText(Execute executeName, const tstring& cardName);
 
 		void RenderCardStateText();
 

--- a/Summoners-Aster/Card/Ability/CardAbilityMediator.cpp
+++ b/Summoners-Aster/Card/Ability/CardAbilityMediator.cpp
@@ -17,29 +17,23 @@ CardAbilityMediator::~CardAbilityMediator()
 
 }
 
-bool CardAbilityMediator::Activator(ActivationEvent activationEvent)
-{
-	bool isSuccess = false;
-	for (auto& card : m_pRegisteredCards)
-	{
-		if (activationEvent == card->m_pFollower->GetActivationEvent()) 
-		{
-			AbilityExecutor::Execute(card);
-			isSuccess = true;
-		}
-	}
-	return isSuccess;
-}
-
 bool CardAbilityMediator::Activator(ActivationEvent activationEvent,Card* card)
 {
 	if (nullptr == card) return false;
 	bool isSuccess = false;
-	if (activationEvent == card->GetActivationEvent())
+
+	//activationEventと同じEventがトリガーである効果が設定されているか確認する
+	std::vector<Ability> abilities = card->Abilities();
+	for (auto ability : abilities)
 	{
-		AbilityExecutor::Execute(card);
-		isSuccess = true;
+		if (activationEvent == ability.activationEvent)
+		{
+			//設定されていたら、効果を呼ぶ
+			AbilityExecutor::Execute(card, ability.execute);
+			isSuccess = true;
+		}
 	}
+
 	return isSuccess;
 }
 
@@ -47,11 +41,19 @@ bool CardAbilityMediator::Activator(ActivationEvent activationEvent, FollowerDat
 {
 	if (nullptr == pFollowerData->m_pFollower) return false;
 	bool isSuccess = false;
-	if (activationEvent == pFollowerData->m_pFollower->GetActivationEvent())
+
+	//activationEventと同じEventがトリガーである効果が設定されているか確認する
+	std::vector<Ability> abilities = pFollowerData->m_pFollower->Abilities();
+	for (auto ability: abilities)
 	{
-		AbilityExecutor::Execute(pFollowerData);
-		isSuccess = true;
+		if (activationEvent == ability.activationEvent)
+		{
+			//設定されていたら、効果を呼ぶ
+			AbilityExecutor::Execute(pFollowerData, ability.execute);
+			isSuccess = true;
+		}
 	}
+
 	return isSuccess;
 }
 

--- a/Summoners-Aster/Card/Ability/CardAbilityMediator.h
+++ b/Summoners-Aster/Card/Ability/CardAbilityMediator.h
@@ -14,13 +14,7 @@ class CardAbilityMediator
 public:
 	CardAbilityMediator();
 	~CardAbilityMediator();
-	/// <summary>
-	/// イベント名によって登録カード効果を発動する
-	/// </summary>
-	/// <param name="activationEvent">イベント名</param>
-	/// <returns>実行の成否</returns>
-	static bool Activator(Ability::ActivationEvent activationEvent);
-
+	
 	/// <summary>
 	/// イベント名によって指定のカード効果を発動する
 	/// </summary>

--- a/Summoners-Aster/Card/Card.cpp
+++ b/Summoners-Aster/Card/Card.cpp
@@ -45,16 +45,28 @@ namespace summonersaster
 		RenderCard(center, size, renderingType, rotationZ);
 	}
 
-	Card::Card(TYPE type, const tstring& name, const tstring& texturePath, int cost, const Ability& ability)
+	Card::Card(TYPE type, const tstring& name, const tstring& texturePath, int cost, std::vector<Ability> abilities)
 		: CARD_TYPE(type), m_name(name), m_texturePath(texturePath), m_cost(cost), pTEXTURE_KEY(m_name.c_str()),
-		m_owner(PLAYER_KIND::PROPONENT), m_ability(ability)
+		m_owner(PLAYER_KIND::PROPONENT)
 	{
+		for (int abilityNum = 0; abilityNum < abilities.size(); ++abilityNum)
+		{
+			Ability ability((abilities[abilityNum].activationEvent), (abilities[abilityNum].execute));
+			m_abilities.push_back(ability);
+		}
+
 		Initialize();
 	}
 
-	Card::Card(TYPE type, const tstring& name, const tstring& texturePath, int cost, PLAYER_KIND owner, const TCHAR* pTextureKey, const Ability& ability)
-		: CARD_TYPE(type), m_name(name), m_texturePath(texturePath), m_cost(cost), pTEXTURE_KEY(pTextureKey), m_owner(owner), m_ability(ability)
+	Card::Card(TYPE type, const tstring& name, const tstring& texturePath, int cost, PLAYER_KIND owner, const TCHAR* pTextureKey, std::vector<Ability> pAbilities)
+		: CARD_TYPE(type), m_name(name), m_texturePath(texturePath), m_cost(cost), pTEXTURE_KEY(pTextureKey), m_owner(owner)
 	{
+		for (int abilityNum = 0; abilityNum < pAbilities.size(); ++abilityNum)
+		{
+			Ability ability((pAbilities[abilityNum].activationEvent),(pAbilities[abilityNum].execute));
+			m_abilities.push_back(ability);
+		}
+
 		Initialize();
 	}
 

--- a/Summoners-Aster/Card/Card.h
+++ b/Summoners-Aster/Card/Card.h
@@ -126,20 +126,9 @@ namespace summonersaster
 			m_shouldDestroyed = shouldDestroyed;
 		}
 
-		inline Ability::Execute GetExcute() 
+		inline std::vector<Ability> Abilities()
 		{
-			return m_ability.execute;
-		}
-
-		inline Ability::ActivationEvent GetActivationEvent() 
-		{
-			return m_ability.activationEvent;
-		}
-
-		inline void SetAbility(const Ability& ability) 
-		{
-			m_ability.activationEvent = ability.activationEvent;
-			m_ability.execute = ability.execute;
+			return m_abilities;
 		}
 
 		const TYPE CARD_TYPE;
@@ -147,8 +136,8 @@ namespace summonersaster
 		const TCHAR* pTEXTURE_KEY = nullptr;
 
 	protected:
-		Card(TYPE type, const tstring& name, const tstring& texturePath, int cost, const Ability& ability);
-		Card(TYPE type, const tstring& name, const tstring& texturePath, int cost, PLAYER_KIND owner, const TCHAR* pTextureKey, const Ability& ability);
+		Card(TYPE type, const tstring& name, const tstring& texturePath, int cost, std::vector<Ability> abilities);
+		Card(TYPE type, const tstring& name, const tstring& texturePath, int cost, PLAYER_KIND owner, const TCHAR* pTextureKey, std::vector<Ability> abilities);
 
 		Card(Card& card) = delete;
 
@@ -175,7 +164,8 @@ namespace summonersaster
 
 		Vertices* m_pCostRect = nullptr;
 		Stream* m_pCostStream = 0;
-		Ability m_ability;
+
+		std::vector<Ability> m_abilities;
 
 		gameframework::Vertices* m_pRect = nullptr;
 

--- a/Summoners-Aster/Card/CardFolder.cpp
+++ b/Summoners-Aster/Card/CardFolder.cpp
@@ -82,34 +82,47 @@ namespace summonersaster
 	void CardFolder::Register(tstringstream* pTypeConverter)
 	{
 		CardComponentData cardComponentData;
-
+		
 		(*pTypeConverter) >> cardComponentData.m_cardTypeTmp >> cardComponentData.m_cardName >>
 			cardComponentData.m_cost >> cardComponentData.m_attack >> cardComponentData.m_hP >>
 			cardComponentData.m_activationTypeTmp >> cardComponentData.m_actionTypeTmp >>
 			cardComponentData.m_cardTexturePath;
+	
+		std::vector<Ability> abilitiesTmp;
+		while (cardComponentData.m_activationTypeTmp != -1 && cardComponentData.m_actionTypeTmp != -1)
+		{
+			//正常に読み込めた情報でAbility構造体をつくる
+			Ability abilityTmp(static_cast<Ability::ActivationEvent>(cardComponentData.m_activationTypeTmp),
+				static_cast<Ability::Execute>(cardComponentData.m_actionTypeTmp));
+			//それをVectorに詰め、このVectorを渡すことで、複数効果持ちのカードを実現する
+			abilitiesTmp.push_back(abilityTmp);
+
+			//読み込めないときを検出するために-1を詰める
+			cardComponentData.m_activationTypeTmp = -1;
+			cardComponentData.m_actionTypeTmp = -1;
+
+			//ここでpTypeConverterから値を受け取れなければ-1のままになる
+			(*pTypeConverter) >> cardComponentData.m_activationTypeTmp >> cardComponentData.m_actionTypeTmp;
+		}
 
 		Card::TYPE cardType = static_cast<Card::TYPE>(cardComponentData.m_cardTypeTmp);
-
-		Ability ability(static_cast<Ability::ActivationEvent>(cardComponentData.m_activationTypeTmp),
-			static_cast<Ability::Execute>(cardComponentData.m_actionTypeTmp));
-
 		switch (cardType)
 		{
 		case Card::TYPE::FOLLOWER:
 			Register(new Follower(cardComponentData.m_cardName, cardComponentData.m_cardTexturePath,
-				cardComponentData.m_cost, cardComponentData.m_attack, cardComponentData.m_hP, ability));
+				cardComponentData.m_cost, cardComponentData.m_attack, cardComponentData.m_hP, abilitiesTmp));
 
 			break;
 
 		case Card::TYPE::SPELL:
 			Register(new Spell(cardComponentData.m_cardName, cardComponentData.m_cardTexturePath,
-				cardComponentData.m_cost, ability));
+				cardComponentData.m_cost, abilitiesTmp));
 
 			break;
 
 		case Card::TYPE::WEAPON:
 			Register(new Weapon(cardComponentData.m_cardName, cardComponentData.m_cardTexturePath,
-				cardComponentData.m_cost, cardComponentData.m_hP, ability));
+				cardComponentData.m_cost, cardComponentData.m_hP, abilitiesTmp));
 
 			break;
 		}

--- a/Summoners-Aster/Card/Follower/Follower.cpp
+++ b/Summoners-Aster/Card/Follower/Follower.cpp
@@ -4,14 +4,14 @@ namespace summonersaster
 {
 	using namespace gameframework;
 
-	Follower::Follower(const tstring& name, const tstring& texturePath, int cost, int attack, int hitPoint, const Ability& ability)
-		: Card(TYPE::FOLLOWER, name, texturePath, cost, ability), m_attack(attack), m_hP(hitPoint)
+	Follower::Follower(const tstring& name, const tstring& texturePath, int cost, int attack, int hitPoint, std::vector<Ability> abilities)
+		: Card(TYPE::FOLLOWER, name, texturePath, cost, abilities), m_attack(attack), m_hP(hitPoint), m_originalAttack(attack)
 	{
 		InitializeStream();
 	}
 
-	Follower::Follower(const tstring& name, const tstring& texturePath, int cost, int attack, int hitPoint, PLAYER_KIND owner, const TCHAR* pTextureKey, const Ability& ability)
-		: Card(TYPE::FOLLOWER, name, texturePath, cost, owner, pTextureKey, ability), m_attack(attack), m_hP(hitPoint)
+	Follower::Follower(const tstring& name, const tstring& texturePath, int cost, int attack, int hitPoint, PLAYER_KIND owner, const TCHAR* pTextureKey, std::vector<Ability> abilities)
+		: Card(TYPE::FOLLOWER, name, texturePath, cost, owner, pTextureKey, abilities), m_attack(attack), m_hP(hitPoint), m_originalAttack(attack)
 	{
 		InitializeStream();
 	}
@@ -24,7 +24,7 @@ namespace summonersaster
 
 	void Follower::CreateCopy(Card** ppCard, PLAYER_KIND owner)const
 	{
-		*ppCard = new Follower(m_name, m_texturePath, m_cost, m_attack, m_hP, owner, pTEXTURE_KEY, m_ability);
+		*ppCard = new Follower(m_name, m_texturePath, m_cost, m_attack, m_hP, owner, pTEXTURE_KEY, m_abilities);
 	}
 
 	Follower& Follower::operator-=(const Follower* pFollower)

--- a/Summoners-Aster/Card/Follower/Follower.h
+++ b/Summoners-Aster/Card/Follower/Follower.h
@@ -9,8 +9,8 @@ namespace summonersaster
 	class Follower :public Card
 	{
 	public:
-		Follower(const tstring& name, const tstring& texturePath, int cost, int attack, int hitPoint, const Ability& ability);
-		Follower(const tstring& name, const tstring& texturePath, int cost, int attack, int hitPoint, PLAYER_KIND owner, const TCHAR* pTextureKey, const Ability& ability);
+		Follower(const tstring& name, const tstring& texturePath, int cost, int attack, int hitPoint, std::vector<Ability> abilities);
+		Follower(const tstring& name, const tstring& texturePath, int cost, int attack, int hitPoint, PLAYER_KIND owner, const TCHAR* pTextureKey, std::vector<Ability> abilities);
 
 		~Follower();
 

--- a/Summoners-Aster/Card/Spell/Spell.cpp
+++ b/Summoners-Aster/Card/Spell/Spell.cpp
@@ -2,13 +2,13 @@
 
 namespace summonersaster
 {
-	Spell::Spell(const tstring& name, const tstring& texturePath, int cost, const Ability& ability)
-		: Card(TYPE::SPELL, name, texturePath, cost, ability)
+	Spell::Spell(const tstring& name, const tstring& texturePath, int cost, std::vector<Ability> abilities)
+		: Card(TYPE::SPELL, name, texturePath, cost, abilities)
 	{
 	}
 
-	Spell::Spell(const tstring& name, const tstring& texturePath, int cost, PLAYER_KIND owner, const TCHAR* pTextureKey, const Ability& ability)
-		: Card(TYPE::SPELL, name, texturePath, cost, owner, pTextureKey, ability)
+	Spell::Spell(const tstring& name, const tstring& texturePath, int cost, PLAYER_KIND owner, const TCHAR* pTextureKey, std::vector<Ability> abilities)
+		: Card(TYPE::SPELL, name, texturePath, cost, owner, pTextureKey, abilities)
 	{
 	}
 
@@ -18,7 +18,7 @@ namespace summonersaster
 
 	void Spell::CreateCopy(Card** ppCard, PLAYER_KIND owner)const
 	{
-		*ppCard = new Spell(m_name, m_texturePath, m_cost, owner, pTEXTURE_KEY, m_ability);
+		*ppCard = new Spell(m_name, m_texturePath, m_cost, owner, pTEXTURE_KEY, m_abilities);
 	}
 
 } // namespace summonersaster

--- a/Summoners-Aster/Card/Spell/Spell.h
+++ b/Summoners-Aster/Card/Spell/Spell.h
@@ -8,8 +8,8 @@ namespace summonersaster
 	class Spell :public Card
 	{
 	public:
-		Spell(const tstring& name, const tstring& texturePath, int cost, const Ability& ability);
-		Spell(const tstring& name, const tstring& texturePath, int cost, PLAYER_KIND owner, const TCHAR* pTextureKey, const Ability& ability);
+		Spell(const tstring& name, const tstring& texturePath, int cost, std::vector<Ability> abilities);
+		Spell(const tstring& name, const tstring& texturePath, int cost, PLAYER_KIND owner, const TCHAR* pTextureKey, std::vector<Ability> abilities);
 
 		~Spell();
 		

--- a/Summoners-Aster/Card/Weapon/Weapon.cpp
+++ b/Summoners-Aster/Card/Weapon/Weapon.cpp
@@ -4,14 +4,14 @@ namespace summonersaster
 {
 	using namespace gameframework;
 
-	Weapon::Weapon(const tstring& name, const tstring& texturePath, int cost, int hitPoint, const Ability& ability)
-		: Card(TYPE::WEAPON, name, texturePath, cost, ability), m_hP(hitPoint)
+	Weapon::Weapon(const tstring& name, const tstring& texturePath, int cost, int hitPoint, std::vector<Ability> abilities)
+		: Card(TYPE::WEAPON, name, texturePath, cost, abilities), m_hP(hitPoint)
 	{
 		gameframework::GameFrameworkFactory::Create(&m_pHPStream);
 	}
 
-	Weapon::Weapon(const tstring& name, const tstring& texturePath, int cost, int hitPoint, PLAYER_KIND owner, const TCHAR* pTextureKey, const Ability& ability)
-		: Card(TYPE::WEAPON, name, texturePath, cost, owner, pTextureKey, ability), m_hP(hitPoint)
+	Weapon::Weapon(const tstring& name, const tstring& texturePath, int cost, int hitPoint, PLAYER_KIND owner, const TCHAR* pTextureKey, std::vector<Ability> abilities)
+		: Card(TYPE::WEAPON, name, texturePath, cost, owner, pTextureKey, abilities), m_hP(hitPoint)
 	{
 		gameframework::GameFrameworkFactory::Create(&m_pHPStream);
 	}
@@ -22,7 +22,7 @@ namespace summonersaster
 
 	void Weapon::CreateCopy(Card** ppCard, PLAYER_KIND owner)const
 	{
-		*ppCard = new Weapon(m_name, m_texturePath, m_cost, m_hP, owner, pTEXTURE_KEY, m_ability);
+		*ppCard = new Weapon(m_name, m_texturePath, m_cost, m_hP, owner, pTEXTURE_KEY, m_abilities);
 	}
 
 	void Weapon::Render(const D3DXVECTOR3& center, const RectSize& size, RENDERING_TYPE renderingType, const Degree& rotationZ)

--- a/Summoners-Aster/Card/Weapon/Weapon.h
+++ b/Summoners-Aster/Card/Weapon/Weapon.h
@@ -8,8 +8,9 @@ namespace summonersaster
 	class Weapon :public Card
 	{
 	public:
-		Weapon(const tstring& name, const tstring& texturePath, int cost, int hitPoint, const Ability& ability);
-		Weapon(const tstring& name, const tstring& texturePath, int cost, int hitPoint, PLAYER_KIND owner, const TCHAR* pTextureKey, const Ability& ability);
+		Weapon(const tstring& name, const tstring& texturePath, int cost, int hitPoint, std::vector<Ability> abilities);
+		Weapon(const tstring& name, const tstring& texturePath, int cost, int hitPoint, PLAYER_KIND owner, const TCHAR* pTextureKey, std::vector<Ability> abilitiesy);
+
 		~Weapon();
 
 		/// <summary>

--- a/Summoners-Aster/SceneSwitcher/Scene/DeckEditScene/EditDeck/EditDeck.cpp
+++ b/Summoners-Aster/SceneSwitcher/Scene/DeckEditScene/EditDeck/EditDeck.cpp
@@ -107,7 +107,6 @@ void EditDeck::Load(PLAYER_KIND owner)
 		Card* card = rCardFolder.CreateCopy(tch, owner);
 		Editor* editor = new Editor(card, new Button());
 		m_EditCards[i] = editor;
-		m_EditCards[i]->pCard->SetAbility(Ability(Ability::ROTATE, Ability::DRAWCARD));
 	}
 	if (LIMIT_CAPACITY != m_EditCards.size())
 	{

--- a/Summoners-Aster/SceneSwitcher/Scene/DeckEditScene/HavingCards/HavingCards.cpp
+++ b/Summoners-Aster/SceneSwitcher/Scene/DeckEditScene/HavingCards/HavingCards.cpp
@@ -35,8 +35,6 @@ void HavingCards::Load(PLAYER_KIND owner)
 		Card* card = rCardFolder.CreateCopy(rCardFolder.GetCardName(i), owner);
 		Having* having = new Having(card, new Button());
 		m_HavingCards[i] = having;
-
-		m_HavingCards[i]->pCard->SetAbility(Ability(Ability::ROTATE, Ability::DRAWCARD));
 	}
 }
 

--- a/Summoners-Aster/SceneSwitcher/Scene/MainScene/BattlePlayer/BattlePlayer.cpp
+++ b/Summoners-Aster/SceneSwitcher/Scene/MainScene/BattlePlayer/BattlePlayer.cpp
@@ -261,7 +261,12 @@ bool BattlePlayer::UpdateSpellingRoutine()
 
 	m_pCemetery->PreserveCard(m_pSpellTmp->HCard());
 
-	AbilityExecutor::Execute(m_pSpellTmp->HCard());
+	//効果が複数あるときのためにfor文で回す
+	std::vector<Ability> abilities = m_pSpellTmp->HCard()->Abilities();
+	for (auto ability : abilities)
+	{
+		AbilityExecutor::Execute(m_pSpellTmp->HCard(), ability.execute);
+	}
 
 	delete m_pSpellTmp;
 	m_pSpellTmp = nullptr;

--- a/Summoners-Aster/SceneSwitcher/Scene/MainScene/Field/Field.cpp
+++ b/Summoners-Aster/SceneSwitcher/Scene/MainScene/Field/Field.cpp
@@ -492,7 +492,7 @@ namespace summonersaster
 	void Field::Followers::ActivateAbirity(int index)
 	{
 		//効果発動イベントディスパッチ
-		CardAbilityMediator::Activator(Ability::ODRERED,&m_followerDatas[index]);
+		CardAbilityMediator::Activator(Ability::ODRERED, &m_followerDatas[index]);
 	}
 
 	void Field::Followers::EmptyFollower(int index)

--- a/Summoners-Aster/SceneSwitcher/Scene/MainScene/WeaponHolder/WeaponHolder.cpp
+++ b/Summoners-Aster/SceneSwitcher/Scene/MainScene/WeaponHolder/WeaponHolder.cpp
@@ -45,7 +45,12 @@ namespace summonersaster
 	{
 		if (!m_pWeapon) return;
 
-		AbilityExecutor::Execute(m_pWeapon);
+		//効果が複数あるときのためにfor文で回す
+		std::vector<Ability> abilities = m_pWeapon->Abilities();
+		for (auto ability : abilities)
+		{
+			AbilityExecutor::Execute(m_pWeapon, ability.execute);
+		}
 
 		m_pWeapon->DecrementHP();
 	}


### PR DESCRIPTION
## 元Issue
<!-- このPull Requestがマージされたときに閉じるIssue番号 -->
Closes #100 

## 変更内容
<!-- このPull Requestでコードをどのように変更するか/変更したかを列挙する -->
- [x] CSVの読み込みの部分の変更
- [x] 複数効果を持てるように、vectorで保存するように変更
- [x] 複数効果が発動できているか確認
- [x] カード説明の所に複数の効果が描画されるように変更

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
デッキ編成がバグが出ていて起動できないので、デッキ編成画面の効果表示は
しっかりできているかは確認できていない。
